### PR TITLE
RPATH awareness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,25 @@
-doc/all_Doxyfile
-doc/auto_Doxyfile
-doc/core_Doxyfile
-doc/openscenegraph.doxyfile
-doc/openthreads.doxyfile
+**/doc/all_Doxyfile
+**/doc/auto_Doxyfile
+**/doc/core_Doxyfile
+**/doc/openscenegraph.doxyfile
+**/doc/openthreads.doxyfile
 
-doc/OpenSceneGraphReferenceDocs/
-doc/OpenThreadsReferenceDocs/
-doc/*.chm
+**/doc/OpenSceneGraphReferenceDocs/
+**/doc/OpenThreadsReferenceDocs/
+**/doc/*.chm
 
 CMakeDoxyfile.in
 CMakeDoxygenDefaults.cmake
 
 cmake_uninstall.cmake
 
-include/OpenThreads/Config
-include/OpenThreads/Version
-include/osg/Config
-include/osg/GL
-include/osg/Version
-include/osgQt/Version
-src/osgQt/__
+**/include/OpenThreads/Config
+**/include/OpenThreads/Version
+**/include/osg/Config
+**/include/osg/GL
+**/include/osg/Version
+**/include/osgQt/Version
+**/src/osgQt/__
 
 lib/
 bin/
@@ -33,6 +33,10 @@ Makefile
 cmake_install.cmake
 install_manifest*.txt
 .cmake/*
+*.ninja
+.ninja_deps
+.ninja_log
+
 
 
 # Compiled Object files

--- a/src/osgDB/FileUtils.cpp
+++ b/src/osgDB/FileUtils.cpp
@@ -46,6 +46,10 @@ typedef char TCHAR;
 
 #else // unix
 
+#ifdef __unix__
+    #include <dlfcn.h>
+#endif
+
 #if defined( __APPLE__ )
     // I'm not sure how we would handle this in raw Darwin
     // without the AvailablilityMacros.
@@ -1179,6 +1183,20 @@ bool osgDB::containsCurrentWorkingDirectoryReference(const FilePathList& paths)
 
     void osgDB::appendPlatformSpecificLibraryFilePaths(FilePathList& filepath)
     {
+#ifdef __unix__
+        auto* application = dlopen(nullptr, RTLD_LAZY | RTLD_NOLOAD);
+        Dl_serinfo searchInfoSize;
+        dlinfo(application, RTLD_DI_SERINFOSIZE, &searchInfoSize);
+        std::vector<char> searchInfoBuffer(searchInfoSize.dls_size);
+        dlinfo(application, RTLD_DI_SERINFOSIZE, searchInfoBuffer.data());
+        dlinfo(application, RTLD_DI_SERINFO, searchInfoBuffer.data());
+        auto* searchInfo = reinterpret_cast<Dl_serinfo*>(searchInfoBuffer.data());
+
+        for (size_t i = 0; i < searchInfo->dls_cnt; ++i)
+        {
+            filepath.emplace_back(searchInfo->dls_serpath[i].dls_name);
+        }
+#endif
 
        char* ptr;
        if( (ptr = getenv( "LD_LIBRARY_PATH" )) )


### PR DESCRIPTION
Makes the `#else` implementation of `osgDB::appendPlatformSpecificLibraryFilePaths` use `dlfcn.h` stuff to interrogate the real library paths when `__unix__` is defined instead of solely relying on `LD_LIBRARY_PATH` plus a few hardcoded paths. Really, it should have been done this way back in 2004 when the function was originally implemented, as the hardcoded paths already needed updating when 64-bit desktop Linux became normal.

This is required for the new approach to packaging generic Linux builds, but probably makes some things work on Unix distributions that don't use exactly the same list of hardcoded paths that were already used.