### PR TITLE
Backport: Fix GLExtensions static order of deletion bug

### DIFF
--- a/include/osg/GLExtensions
+++ b/include/osg/GLExtensions
@@ -14,6 +14,7 @@
 #ifndef OSG_GLEXTENSIONS
 #define OSG_GLEXTENSIONS 1
 
+#include <osg/observer_ptr>
 #include <osg/Export>
 #include <osg/GLDefines>
 
@@ -830,8 +831,10 @@ class OSG_EXPORT GLExtensions : public osg::Referenced
         /** convenience wrapper around glObjectLabel that calls glObjectLabel if it's supported and using std::string as a label parameter.*/
         void debugObjectLabel(GLenum identifier, GLuint name, const std::string& label) const { if (glObjectLabel && !label.empty()) glObjectLabel(identifier, name, label.size(), label.c_str()); }
 
+        struct ExtensionData;
     protected:
         virtual ~GLExtensions();
+        observer_ptr<ExtensionData> _extensionData;
 };
 
 

--- a/src/osg/GLExtensions.cpp
+++ b/src/osg/GLExtensions.cpp
@@ -59,9 +59,14 @@
 using namespace osg;
 
 typedef std::set<std::string>  ExtensionSet;
-static osg::buffered_object<ExtensionSet> s_glExtensionSetList;
-static osg::buffered_object<std::string> s_glRendererList;
-static osg::buffered_value<int> s_glInitializedList;
+struct GLExtensions::ExtensionData : public Referenced
+{
+    osg::buffered_object<ExtensionSet> glExtensionSetList;
+    osg::buffered_object<std::string> glRendererList;
+    osg::buffered_value<int> glInitializedList;
+};
+
+ref_ptr<GLExtensions::ExtensionData> s_extensionData(new GLExtensions::ExtensionData);
 
 static ApplicationUsageProxy GLEXtension_e0(ApplicationUsage::ENVIRONMENTAL_VARIABLE, "OSG_GL_EXTENSION_DISABLE <value>", "Use space deliminarted list of GL extensions to disable associated GL extensions");
 static ApplicationUsageProxy GLEXtension_e1(ApplicationUsage::ENVIRONMENTAL_VARIABLE, "OSG_MAX_TEXTURE_SIZE <value>", "Clamp the maximum GL texture size to specified value.");
@@ -104,8 +109,8 @@ bool osg::isGLExtensionSupported(unsigned int contextID, const char *extension1,
 
 bool osg::isGLExtensionOrVersionSupported(unsigned int contextID, const char *extension, float requiredGLVersion)
 {
-    ExtensionSet& extensionSet = s_glExtensionSetList[contextID];
-    std::string& rendererString = s_glRendererList[contextID];
+    ExtensionSet& extensionSet = s_extensionData->glExtensionSetList[contextID];
+    std::string& rendererString = s_extensionData->glRendererList[contextID];
 
     // first check to see if GL version number of recent enough.
     bool result = requiredGLVersion <= osg::getGLVersionNumber();
@@ -113,9 +118,9 @@ bool osg::isGLExtensionOrVersionSupported(unsigned int contextID, const char *ex
     if (!result)
     {
         // if not already set up, initialize all the per graphic context values.
-        if (!s_glInitializedList[contextID])
+        if (!s_extensionData->glInitializedList[contextID])
         {
-            s_glInitializedList[contextID] = 1;
+            s_extensionData->glInitializedList[contextID] = 1;
 
             // set up the renderer
             const GLubyte* renderer = glGetString(GL_RENDERER);
@@ -439,7 +444,8 @@ void GLExtensions::Set(unsigned int in_contextID, GLExtensions* extensions)
 
 
 GLExtensions::GLExtensions(unsigned int in_contextID):
-    contextID(in_contextID)
+    contextID(in_contextID),
+    _extensionData(s_extensionData)
 {
     const char* versionString = (const char*) glGetString( GL_VERSION );
     bool validContext = versionString!=0;
@@ -1310,9 +1316,13 @@ GLExtensions::GLExtensions(unsigned int in_contextID):
 GLExtensions::~GLExtensions()
 {
     // Remove s_gl*List
-    s_glExtensionSetList[contextID] = ExtensionSet();
-    s_glRendererList[contextID] = std::string();
-    s_glInitializedList[contextID] = 0;
+    ref_ptr<ExtensionData> eData;
+    if (_extensionData.lock(eData))
+    {
+        eData->glExtensionSetList[contextID] = ExtensionSet();
+        eData->glRendererList[contextID] = std::string();
+        eData->glInitializedList[contextID] = 0;
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
~GLExtensions() writes into three file-scope statics (extension set, renderer string, initialised flag). A GLExtensions object can outlive static destruction: every VertexArrayState holds a ref_ptr to it, and the VertexArrayStateManager keeps released states in the ContextData until process exit, so with vertex array objects in use the last one is deleted from exit()'s static destructors after the statics are gone, corrupting the heap and crashing in whichever static destructor frees next. Allocate the registries once and never free them.

Found while getting OpenMW to run on a 4.1 core profile context on macOS, which is where OSG ends up using VAOs.

The process crashed inside libosg's static destructors after the engine's own clean shutdown, about one run in three in my tests, never without VAOs. Guard malloc on macOS turns the heap corruption into an immediate fault at the write in ~GLExtensions.

With this change: clean exit every time, guard malloc quiet. Should be independent of anything else.