### PR TITLE
VertexArrayState: dirty() forces every active array to be dispatched again

### DIFF
--- a/src/osg/VertexArrayState.cpp
+++ b/src/osg/VertexArrayState.cpp
@@ -820,6 +820,15 @@ void VertexArrayState::setInterleavedArrays(osg::State& /*state*/, GLenum format
 
 void VertexArrayState::dirty()
 {
+    // Reached from Drawable::dirtyGLObjects() when one of the drawable's arrays was replaced. Any other array
+    // sharing a buffer object with it may move inside that buffer when it is next compiled, and a vertex array
+    // object keeps the pointers recorded at dispatch time, so every active array has to be dispatched again,
+    // not only the ones whose array or modified count changed.
+    for(ActiveDispatchers::iterator itr = _activeDispatchers.begin(); itr != _activeDispatchers.end(); ++itr)
+    {
+        (*itr)->modifiedCount = 0xffffffff;
+    }
+
     setRequiresSetArrays(true);
 }
 


### PR DESCRIPTION
A vertex array object records the attribute pointer (buffer and offset) at dispatch time. When another array sharing the same VertexBufferObject is replaced or resized, the buffer is re-laid out and unchanged arrays move, but setArray() only re-dispatched on a new array pointer or modified count, so the vertex array object kept a stale offset. Track the buffer object and offset each array was last dispatched with and re-dispatch when they differ; reset them in dirty(). With a vertex array object in use, arrays that were never assigned a buffer object get one, as client-side pointers are not allowed there.

Observed while working on OpenMW on a GL 4.1 core profile context on macOS, alongside PR #50: OpenMW's cloud layer read its colour array from the wrong offset after the sky geometry's other arrays were regenerated, so the clouds drew with the wrong data.

Two things for review: the array gets its buffer object through a const_cast (osg::Geometry does the same internally), and the last-dispatched buffer object is compared by address. The check is gated on a VAO being in use, so the client-array path is untouched.

Mainline OpenSceneGraph master still has the offset-only check.